### PR TITLE
fix unsafe_raw method

### DIFF
--- a/lib/phlex/deferred_render_with_main_content.rb
+++ b/lib/phlex/deferred_render_with_main_content.rb
@@ -4,7 +4,7 @@ module Phlex
   module DeferredRenderWithMainContent
     def view_template(&block)
       output = capture(&block)
-      super { unsafe_raw(output) }
+      super { raw(output) }
     end
   end
 end

--- a/lib/ultimate_turbo_modal/base.rb
+++ b/lib/ultimate_turbo_modal/base.rb
@@ -123,7 +123,7 @@ class UltimateTurboModal::Base < Phlex::HTML
 
   def styles
     style do
-      unsafe_raw("html:has(dialog[open]) {overflow: hidden;} html {scrollbar-gutter: stable;}".html_safe)
+      raw("html:has(dialog[open]) {overflow: hidden;} html {scrollbar-gutter: stable;}".html_safe)
     end
   end
 


### PR DESCRIPTION
Phlex V2 has renamed the unsafe_raw method to raw.

This creates the following error when initializing a modal using the modal helper method:

ActionView::Template::Error (undefined method 'unsafe_raw' for an instance of UltimateTurboModal::Flavors::Tailwind)